### PR TITLE
Few trivial byte-compiler fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,49 @@
+# -*- mode: gitignore; -*-
 *~
-*.fasl
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+

--- a/system-browser-cl.el
+++ b/system-browser-cl.el
@@ -58,10 +58,10 @@ The second argument indicates if include system's direct dependencies or not."
       (setq current-prefix-arg (cdr esb/cl:asdf-system)))
     (system-browser-browse-system (car esb/cl:asdf-system))))
 
-(cl-defmethod esb:system-initialize-definition-buffer ((system esb/cl:common-lisp-system))
+(cl-defmethod esb:system-initialize-definition-buffer ((_system esb/cl:common-lisp-system))
   (lisp-mode))
 
-(cl-defmethod esb:get-module-properties ((system esb/cl:common-lisp-system) module)
+(cl-defmethod esb:get-module-properties ((_system esb/cl:common-lisp-system) module)
   (let* ((module-properties (slime-eval `(esb::serialize-for-emacs (def-properties:package-properties ,module t))))
          (source (cl-find :source module-properties :key 'car))
          (file (and source
@@ -76,7 +76,7 @@ The second argument indicates if include system's direct dependencies or not."
 	  (cons 'position position)
 	  (cons 'documentation documentation))))
 
-(cl-defmethod esb:get-definition-properties ((system esb/cl:common-lisp-system) definition category module)
+(cl-defmethod esb:get-definition-properties ((_system esb/cl:common-lisp-system) definition category module)
   (let ((definition-function
          (cond
           ((string= category "functions") 'def-properties:function-properties)
@@ -99,7 +99,7 @@ The second argument indicates if include system's direct dependencies or not."
 	    (cons 'position position)
 	    (cons 'documentation documentation)))))
 
-(cl-defmethod esb:read-module-name ((system esb/cl:common-lisp-system) prompt)
+(cl-defmethod esb:read-module-name ((_system esb/cl:common-lisp-system) prompt)
   (slime-read-package-name prompt))
 
 (cl-defmethod esb:list-categories ((system esb/cl:common-lisp-system) module)

--- a/system-browser-cl.el
+++ b/system-browser-cl.el
@@ -124,11 +124,11 @@ The second argument indicates if include system's direct dependencies or not."
   (if (zerop (length system-name))
       (oset esb:current-browser-system modules-list-function nil)
     (let ((include-direct-dependencies (not (null current-prefix-arg))))
-      (when esb:load-asdf-systems-on-browse
+      (when esb/cl:load-asdf-systems-on-browse
         (slime-eval `(cl:progn (asdf:operate 'asdf:load-op ,system-name) nil)))
       (oset esb:current-browser-system modules-list-function
             (lambda ()
-              (esb:asdf-system-packages system-name include-direct-dependencies)))))
+              (esb/cl:asdf-system-packages system-name include-direct-dependencies)))))
   (system-browser-refresh))
 
 (defun lisp-system-browser ()
@@ -138,7 +138,7 @@ The second argument indicates if include system's direct dependencies or not."
 
     ;; Start SLIME if needed
     (when (not (slime-connected-p))
-      (when (or esb:start-slime-automatically
+      (when (or esb/cl:start-slime-automatically
                 (yes-or-no-p "SLIME is not connected. Start? "))
         (add-hook 'slime-connected-hook 'system-browser t)
         (slime))

--- a/system-browser.el
+++ b/system-browser.el
@@ -60,8 +60,8 @@ Return value is an alist with keys 'source, 'file, 'position, 'documentation"))
   nil)
 
 (defvar esb:modules-buffer)
-(defvar esb:catgories-buffer)
-(defvar esb:definitions-buffer)
+(defvar esb:categories-buffer)
+(defvar esb:definition-buffer)
 (defvar esb:definitions-buffer)
 (defvar esb:documentation-buffer)
 

--- a/system-browser.el
+++ b/system-browser.el
@@ -34,12 +34,12 @@
 (cl-defgeneric esb:system-initialize-definition-buffer (system-browser-system))
 (cl-defgeneric esb:get-module-properties (system-browser-system module)
   (:documentation "Return properties of MODULE.
-Return value is an alist with keys 'source, 'file, 'position, 'documentation"))
+Return value is an alist with keys \\='source, \\='file, \\='position, \\='documentation"))
 (cl-defgeneric esb:get-definition-properties (system-browser-system definition category module)
   (:documentation "Return properties of DEFINITION.
-Return value is an alist with keys 'source, 'file, 'position, 'documentation"))
+Return value is an alist with keys \\='source, \\='file, \\='position, \\='documentation"))
 
-(cl-defmethod esb:read-module-name (system prompt)
+(cl-defmethod esb:read-module-name (_system _prompt)
   (:documentation "Read module name from minibuffer."))
 
 ;; Default mode-line
@@ -59,6 +59,7 @@ Return value is an alist with keys 'source, 'file, 'position, 'documentation"))
   (ignore system-browser-system)
   nil)
 
+(defvar esb:wm)
 (defvar esb:modules-buffer)
 (defvar esb:categories-buffer)
 (defvar esb:definition-buffer)
@@ -96,7 +97,7 @@ Return value is an alist with keys 'source, 'file, 'position, 'documentation"))
   :tag "List internal definitions")
 
 (defcustom esb:preserve-definition-buffer-on-exit t
-  "Keep the current system browser definition buffer and file alive when the system browser is closed."
+  "Keep the definition buffer and file alive when the system browser is closed."
   :type 'boolean
   :group 'system-browser
   :tag "Preserve definition buffer on exit")
@@ -368,8 +369,6 @@ Return value is an alist with keys 'source, 'file, 'position, 'documentation"))
 
 ;;---- Window management ---------------------------
 
-(defvar esb:wm)
-
 (defun esb:set-windows-dedicated ()
   (let ((winfo-list (wlf:wset-winfo-list esb:wm)))
     (set-window-dedicated-p (wlf:window-window (wlf:get-winfo 'modules winfo-list)) t)
@@ -430,7 +429,7 @@ Return value is an alist with keys 'source, 'file, 'position, 'documentation"))
 ;;------- Commands ------------------------------------------------
 
 (defun system-browser-reset-layout ()
-  "Reset system browser layout. Use this when Emacs windows break the browser's layout."
+  "Reset the browser layout. Use when Emacs windows break the browser's layout."
   (interactive)
   (wlf:reset-window-sizes esb:wm)
   (esb:initialize-windows))

--- a/system-browser.el
+++ b/system-browser.el
@@ -1,5 +1,13 @@
 ;;; system-browser.el --- System browser      -*- lexical-binding: t -*-
 ;;;
+;; Copyright (C) 2020  Mariano Montone
+
+;; Author: Mariano Montone
+;; Version: 0.5.0
+;; Keywords: tools lisp programming
+;; Package-Requires: ((window-layout) (slime))
+;; URL: https://github.com/mmontone/lisp-system-browser
+
 ;;; Commentary:
 ;;; A Smalltalk-like browser for programming languages.
 


### PR DESCRIPTION
Hi Mariano

Thanks for Slime Star. I have been using it for a while, and it works fine for me. There are few things, mostly trivial, that could be fixed, and there are some things that could be perhaps a bit more automated. For trivial things, I started with system-browser. Seems like you have done some refactoring, so there seem to be some variables that weren't updated, a typo. I tried to fix some other simple warnings too. If you prefer to fix them yourself, or I have misunderstand something you can just close this pr.

For some deeper change, window-layout library you are shipping with Slime Star is outdated. It is an old version with lots of compiler warnings, mostly old cl.el library and some other stuff. The one in Melpa is fixed, so it would be nice if Slime Star didn't ship with the old one, but would use the one from Melpa. System-browser.el seems to be the only consumer of that library, so that is why I started to hack on it. I thought to turn it into an "ordinary" package.el, or at least something installable via package.el if you don't care to try to include it into Melpa or Elpa. The idea is to add the package header to the system-browser.el, and let package.el fetch the dependency.  I think the system-browser.el would have to be renamed to lisp-system-browser.el to make package.el happy. I haven't done that yet. One thing I am not sure I understand how to do is how to manage Common Lisp part of the library (cl-def-properties) via package.el, but Sly/Slime do that, so I'll have to look at how they do it.

Slime Star could than also be turned into a package installable via package.el too and just refer to lisp-system-browser as a dependency instead of including it directly.

What do you think?